### PR TITLE
Set config file defines in Makefile.am

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -65,11 +65,5 @@ AC_CHECK_TYPES([socklen_t], , , [
 #include <sys/socket.h>
 ])
 
-EXPANDED_SYSCONFDIR=`eval echo $sysconfdir`
-AC_DEFINE_UNQUOTED([MAINCFG], "$EXPANDED_SYSCONFDIR/libnss-mysql.cfg",
-                   [Main config file])
-AC_DEFINE_UNQUOTED([ROOTCFG],"$EXPANDED_SYSCONFDIR/libnss-mysql-root.cfg",
-                   [Root config file])
-
 AC_CONFIG_FILES([Makefile src/Makefile src/version.c])
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -25,7 +25,7 @@ library_ldflags         = -module -version-info @LIBVER@:0:0 \
                           -export-symbols $(srcdir)/@OS@.sym
 
 lib_LTLIBRARIES         = libnss_mysql.la
-libnss_mysql_la_CFLAGS  = @MYSQL_CFLAGS@
+libnss_mysql_la_CFLAGS  = @MYSQL_CFLAGS@ -DROOTCFG='"$(sysconfdir)/libnss-mysql-root.cfg"' -DMAINCFG='"$(sysconfdir)/libnss-mysql.cfg"'
 libnss_mysql_la_LDFLAGS = @MYSQL_LDFLAGS@ $(library_ldflags)
 libnss_mysql_la_SOURCES = $(library_sources)
 


### PR DESCRIPTION
This change fixes building the project after running ./configure without any arguments. (i.e. no --prefix=...) Previously this would lead to the library looking for configuration files in `NONE/etc/...`